### PR TITLE
Fix/issue 7231 unrecognized cop warning does not exit with 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,5 +35,5 @@ Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler.
 
 ```
 $ [bundle exec] rubocop -V
-0.76.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
+0.77.0 (using Parser 2.5.1.2, running on ruby 2.5.1 x86_64-linux)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
 * [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
+* [#7534](https://github.com/rubocop-hq/rubocop/issues/7534): Fix an incorrect autocorrect for `Style/BlockDelimiters` cop and `Layout/SpaceBeforeBlockBraces` cop with `EnforcedStyle: no_space` when using multiline braces. ([@koic][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
+
 ## 0.77.0 (2019-11-27)
 
 ### Bug fixes
@@ -4267,3 +4271,4 @@
 [@avmnu-sng]: https://github.com/avmnu-sng
 [@ayacai115]: https://github.com/ayacai115
 [@ozydingo]: https://github.com/ozydingo
+[@movermeyer]: https://github.com/movermeyer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
+* [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
 
 ## 0.77.0 (2019-11-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.77.0 (2019-11-27)
+
 ### Bug fixes
 
 * [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#7530](https://github.com/rubocop-hq/rubocop/issues/7530): Typo in `Style/TrivialAccessors`'s `AllowedMethods`. ([@movermeyer][])
 * [#7532](https://github.com/rubocop-hq/rubocop/issues/7532): Fix an error for `Style/TrailingCommaInArguments` when using an anonymous function with multiple line arguments with `EnforcedStyleForMultiline: consistent_comma`. ([@koic][])
 * [#7534](https://github.com/rubocop-hq/rubocop/issues/7534): Fix an incorrect autocorrect for `Style/BlockDelimiters` cop and `Layout/SpaceBeforeBlockBraces` cop with `EnforcedStyle: no_space` when using multiline braces. ([@koic][])
+* [#7231](https://github.com/rubocop-hq/rubocop/issues/7231): Fix the exit code to be `2` rather when `0` when the config file contains an unknown cop. ([@jethroo][])
 
 ## 0.77.0 (2019-11-27)
 
@@ -4274,3 +4275,4 @@
 [@ayacai115]: https://github.com/ayacai115
 [@ozydingo]: https://github.com/ozydingo
 [@movermeyer]: https://github.com/movermeyer
+[@jethroo]: https://github.com/jethroo

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
 might want to use a conservative version lock in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 0.76.0', require: false
+gem 'rubocop', '~> 0.77.0', require: false
 ```
 
 ## Quickstart

--- a/config/default.yml
+++ b/config/default.yml
@@ -3842,7 +3842,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  AllowedMethod:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -41,7 +41,7 @@ module RuboCop
 
       @config_obsoletion.reject_obsolete_cops_and_parameters
 
-      warn_about_unrecognized_cops(invalid_cop_names)
+      alert_about_unrecognized_cops(invalid_cop_names)
       check_target_ruby
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
@@ -96,7 +96,8 @@ module RuboCop
       raise ValidationError, msg
     end
 
-    def warn_about_unrecognized_cops(invalid_cop_names)
+    def alert_about_unrecognized_cops(invalid_cop_names)
+      unknown_cops = []
       invalid_cop_names.each do |name|
         # There could be a custom cop with this name. If so, don't warn
         next if Cop::Cop.registry.contains_cop_matching?([name])
@@ -106,9 +107,10 @@ module RuboCop
         # to do so than to pass the value around to various methods.
         next if name == 'inherit_mode'
 
-        warn Rainbow("Warning: unrecognized cop #{name} found in " \
-                     "#{smart_loaded_path}").yellow
+        unknown_cops << "unrecognized cop #{name} found in " \
+          "#{smart_loaded_path}"
       end
+      raise ValidationError, unknown_cops.join(', ') if unknown_cops.any?
     end
 
     def validate_syntax_cop

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -217,7 +217,7 @@ module RuboCop
         !relevant_file?(file)
       end
 
-      # This method should be overriden when a cop's behavior depends
+      # This method should be overridden when a cop's behavior depends
       # on state that lives outside of these locations:
       #
       #   (1) the file under inspection

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -93,9 +93,12 @@ module RuboCop
       end
 
       def method_name_and_arguments_on_same_line?(node)
-        %i[send csend].include?(node.type) &&
-          node.loc.selector.line == node.arguments.last.last_line &&
-          node.last_line == node.arguments.last.last_line
+        return false unless node.call_type?
+
+        line = node.loc.selector.nil? ? node.loc.line : node.loc.selector.line
+
+        line == node.last_argument.last_line &&
+          node.last_line == node.last_argument.last_line
       end
 
       # A single argument with the closing bracket on the same line as the end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   # This module holds the RuboCop version information.
   module Version
-    STRING = '0.76.0'
+    STRING = '0.77.0'
 
     MSG = '%<version>s (using Parser %<parser_version>s, running on ' \
           '%<ruby_engine>s %<ruby_version>s %<ruby_platform>s)'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -7182,7 +7182,7 @@ ExactNameMatch | `true` | Boolean
 AllowPredicates | `true` | Boolean
 AllowDSLWriters | `false` | Boolean
 IgnoreClassMethods | `false` | Boolean
-AllowedMethod | `to_ary`, `to_a`, `to_c`, `to_enum`, `to_h`, `to_hash`, `to_i`, `to_int`, `to_io`, `to_open`, `to_path`, `to_proc`, `to_r`, `to_regexp`, `to_str`, `to_s`, `to_sym` | Array
+AllowedMethods | `to_ary`, `to_a`, `to_c`, `to_enum`, `to_h`, `to_hash`, `to_i`, `to_int`, `to_io`, `to_open`, `to_path`, `to_proc`, `to_r`, `to_regexp`, `to_str`, `to_s`, `to_sym` | Array
 
 ### References
 

--- a/manual/installation.md
+++ b/manual/installation.md
@@ -16,7 +16,7 @@ haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you
 might want to use a conservative version locking in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 0.76.0', require: false
+gem 'rubocop', '~> 0.77.0', require: false
 ```
 
 !!! Note

--- a/relnotes/v0.77.0.md
+++ b/relnotes/v0.77.0.md
@@ -1,0 +1,21 @@
+### Bug fixes
+
+* [#7493](https://github.com/rubocop-hq/rubocop/issues/7493): Fix `Style/RedundantReturn` to inspect conditional constructs that are preceded by other statements. ([@buehmann][])
+* [#7509](https://github.com/rubocop-hq/rubocop/issues/7509): Fix `Layout/SpaceInsideArrayLiteralBrackets` to correct empty lines. ([@ayacai115][])
+* [#7517](https://github.com/rubocop-hq/rubocop/issues/7517): `Style/SpaceAroundKeyword` allows `::` after `super`. ([@ozydingo][])
+* [#7515](https://github.com/rubocop-hq/rubocop/issues/7515): Fix a false negative for `Style/RedundantParentheses` when calling a method with safe navigation operator. ([@koic][])
+* [#7477](https://github.com/rubocop-hq/rubocop/issues/7477): Fix line length autocorrect for semicolons in string literals. ([@maxh][])
+* [#7522](https://github.com/rubocop-hq/rubocop/pull/7522): Fix a false-positive edge case (`n % 2 == 2`) for `Style/EvenOdd`. ([@buehmann][])
+
+### Changes
+
+* [#7077](https://github.com/rubocop-hq/rubocop/issues/7077): **(Breaking)** Further standardisation of cop names. ([@scottmatthewman][])
+* [#7469](https://github.com/rubocop-hq/rubocop/pull/7469): **(Breaking)** Replace usages of the terms `Whitelist` and `Blacklist` with better alternatives. ([@koic][])
+* [#7502](https://github.com/rubocop-hq/rubocop/pull/7502): Remove `SafeMode` module. ([@koic][])
+
+[@buehmann]: https://github.com/buehmann
+[@ayacai115]: https://github.com/ayacai115
+[@ozydingo]: https://github.com/ozydingo
+[@koic]: https://github.com/koic
+[@maxh]: https://github.com/maxh
+[@scottmatthewman]: https://github.com/scottmatthewman

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1653,6 +1653,32 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
+  it 'corrects Style/BlockDelimiters offenses when specifing' \
+     'Layout/SpaceBeforeBlockBraces with `EnforcedStyle: no_space` together' do
+    create_file('example.rb', <<~RUBY)
+      foo {
+        bar
+      }
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/SpaceBeforeBlockBraces:
+        EnforcedStyle: no_space
+    YAML
+
+    expect(cli.run([
+                     '--auto-correct',
+                     '--only',
+                     'Style/BlockDelimiters,Layout/SpaceBeforeBlockBraces'
+                   ])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(IO.read('example.rb')).to eq(<<~RUBY)
+      foo do
+        bar
+      end
+    RUBY
+  end
+
   it 'corrects BracesAroundHashParameters offenses leaving the ' \
      'MultilineHashBraceLayout offense unchanged' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1653,7 +1653,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
     RUBY
   end
 
-  it 'corrects Style/BlockDelimiters offenses when specifing' \
+  it 'corrects Style/BlockDelimiters offenses when specifying' \
      'Layout/SpaceBeforeBlockBraces with `EnforcedStyle: no_space` together' do
     create_file('example.rb', <<~RUBY)
       foo {

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1415,7 +1415,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
-    it 'prints a warning for an unrecognized cop name in .rubocop.yml' do
+    it 'prints an error for an unrecognized cop name in .rubocop.yml' do
       create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', <<~YAML)
@@ -1424,9 +1424,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Max: 100
       YAML
 
-      expect(cli.run(%w[--format simple example])).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
-        .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' \
+        .to eq(['Error: unrecognized cop Style/LyneLenth found in ' \
                 'example/.rubocop.yml',
                 ''].join("\n"))
     end
@@ -1695,6 +1695,22 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
            '`Style/TrailingCommaInHashLiteral` instead.',
            '(obsolete configuration found in .rubocop.yml, ' \
            'please update it)'].join("\n")
+        )
+      end
+    end
+  end
+
+  describe 'unknown cop' do
+    context 'in configuration file is given' do
+      it 'prints the error and exists with code 2' do
+        create_file('example1.rb', "puts 'no offenses here'")
+        create_file('.rubocop.yml', <<~YAML)
+          Syntax/Whatever:
+            Enabled: true
+        YAML
+        expect(cli.run(['example1.rb'])).to eq(2)
+        expect($stderr.string.strip).to eq(
+          'Error: unrecognized cop Syntax/Whatever found in .rubocop.yml'
         )
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::Config do
 
   describe '#validate', :isolated_environment do
     subject(:configuration) do
+      # ConfigLoader.load_file will validate config
       RuboCop::ConfigLoader.load_file(configuration_path)
     end
 
@@ -29,9 +30,11 @@ RSpec.describe RuboCop::Config do
         $stderr = STDERR
       end
 
-      it 'prints a warning message' do
-        configuration # ConfigLoader.load_file will validate config
-        expect($stderr.string).to match(/unrecognized cop LyneLenth/)
+      it 'raises an validation error' do
+        expect { configuration }.to raise_error(
+          RuboCop::ValidationError,
+          'unrecognized cop LyneLenth found in .rubocop.yml'
+        )
       end
     end
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -302,8 +302,12 @@ RSpec.describe RuboCop::Cop::Generator do
 
     around do |example|
       orig_registry = RuboCop::Cop::Cop.registry
-      RuboCop::Cop::Cop.instance_variable_set(:@registry,
-                                              RuboCop::Cop::Registry.new)
+      RuboCop::Cop::Cop.instance_variable_set(
+        :@registry,
+        RuboCop::Cop::Registry.new(
+          [RuboCop::Cop::InternalAffairs::NodeDestructuring]
+        )
+      )
       example.run
       RuboCop::Cop::Cop.instance_variable_set(:@registry, orig_registry)
     end
@@ -320,22 +324,12 @@ RSpec.describe RuboCop::Cop::Generator do
 
     it 'generates a cop file that has no offense' do
       generator.write_source
-      result = nil
-      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
-      OUTPUT
-      expect(result).to be true
+      expect(runner.run([])).to be true
     end
 
     it 'generates a spec file that has no offense' do
       generator.write_spec
-      result = nil
-      expect { result = runner.run([]) }.to output(<<~OUTPUT).to_stderr
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop_todo.yml
-        Warning: unrecognized cop InternalAffairs/NodeDestructuring found in #{HOME_DIR}/.rubocop.yml
-      OUTPUT
-      expect(result).to be true
+      expect(runner.run([])).to be true
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -142,6 +142,23 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
   end
 
+  context 'with a single argument of anonymous function ' \
+          'spanning multiple lines' do
+    context 'when EnforcedStyleForMultiline is consistent_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
+
+      it 'accepts a single argument with no trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          func.(
+            'foo',
+            'bar',
+            'baz',
+          )
+        RUBY
+      end
+    end
+  end
+
   context 'with multi-line list of values' do
     context 'when EnforcedStyleForMultiline is no_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
       formatter.file_finished('test_a.rb', offenses)
       formatter.file_started('test_b.rb', {})
       formatter.file_finished('test_b.rb', [offenses.first])
+
+      # Cop1 and Cop2 are unknown cops and would raise an validation error
+      allow(RuboCop::Cop::Cop.registry).to receive(:contains_cop_matching?)
+        .and_return(true)
       formatter.finished(['test_a.rb', 'test_b.rb'])
     end
 


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
